### PR TITLE
Fix bug where memory check fails on systems with more than 10 GB of memory.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # Check if we have enough memory
-if [[ `free -m | grep Mem | cut -d " " -f 12` -lt 1024 ]]; then
+if [[ `free -m | awk '/^Mem:/{print $2}'` -lt 1024 ]]; then
   echo "This installation requires at least 1GB of RAM.";
   exit 1
 fi


### PR DESCRIPTION
The output of `free -m` is left padded, so when the amount of memory is above 10 GB there's one less space and the check fails.
This occurs backwards too, and it immediately fails when there's less than 1 GB of ram, however that doesn't matter anyway.
```
Mem:          10000
Mem:           1000
Mem:            100
```