### PR TITLE
Change the required amount of memory to 900 MB.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # Check if we have enough memory
-if [[ `free -m | awk '/^Mem:/{print $2}'` -lt 1024 ]]; then
+if [[ `free -m | awk '/^Mem:/{print $2}'` -lt 900 ]]; then
   echo "This installation requires at least 1GB of RAM.";
   exit 1
 fi


### PR DESCRIPTION
Vultr 1 GB VPS' appear to have slightly less than 1 GB of memory, this commit changes the requirement to slightly less than 1 GB in the case of discrepancies between 1 GB plans on VPS hosts.