### PR TITLE
Patch to fix an error most users are getting.

### DIFF
--- a/refresh_node.sh
+++ b/refresh_node.sh
@@ -40,6 +40,10 @@ fi
 echo "Your masternode is syncing. Please wait for this process to finish."
 echo "This can take up to a few hours. Do not close this window." && echo ""
 
+until [  $(bulwark-cli getconnectioncount) -gt 0  ] 2>/dev/nul; do
+  sleep 1
+done
+
 until su -c "bulwark-cli mnsync status 2>/dev/null | grep '\"IsBlockchainSynced\" : true' > /dev/null" $USER; do
   echo -ne "Current block: "`su -c "bulwark-cli getinfo" $USER | grep blocks | awk '{print $3}' | cut -d ',' -f 1`'\r'
   sleep 1


### PR DESCRIPTION
Script runs a command calling bulwark-cli before bulwark-cli finishes launching, this causes errors and breaks the script.

In future, all tests in our scripts straight after starting bulwarkd should be preceeded by similar checks as now our blockchain is getting bigger, it's taking time to load the wallet.